### PR TITLE
BUGFIX get script URL with helper method

### DIFF
--- a/Controller/Payment/CreateOrder.php
+++ b/Controller/Payment/CreateOrder.php
@@ -37,11 +37,14 @@ class CreateOrder extends BaseAPIHandler
         $hash = hash('sha256', $postData . $quote->getCustomerEmail());
 
         $sessionData = $this->checkoutSession->getData(Data::ORDER_SESSION_KEY);
+        $scriptUrl = $this->dataHelper->getCheckoutScriptSourceForEnvironment(
+            $this->getRFPaymentConfig('target_server')
+        );
 
         if ($sessionData && !empty($sessionData[$hash])) {
             $additionalData = [
             'token' => $sessionData[$hash],
-            'script_url' => $this->getRFPaymentConfig(Data::OVERRIDE_SCRIPT_SOURCE_KEY),
+            'script_url' => $scriptUrl,
             ];
             return $this->result(200, 'Order token successfully loaded', $additionalData);
         }
@@ -72,7 +75,7 @@ class CreateOrder extends BaseAPIHandler
         $this->checkoutSession->setData(Data::ORDER_SESSION_KEY, [$hash => $result['token']]);
         $additionalData = [
         'token' => $result['token'],
-        'script_url' => $this->getRFPaymentConfig(Data::OVERRIDE_SCRIPT_SOURCE_KEY),
+        'script_url' => $scriptUrl,
         ];
         return $this->result(200, 'Order successfully created', $additionalData);
     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "lendingworks/magento2-retailfinance",
   "description": "Lending Works Retail Finance integration for Magento 2",
   "type": "magento2-module",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": [
     "OSL-3.0"
   ],


### PR DESCRIPTION
Previous method was failing to pick up a non-override URL, so the checkout would not launch.

This has been tested with both an override and a default URL.